### PR TITLE
Revert back to the previous trivy action version

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -27,17 +27,13 @@ jobs:
       - name: Create lib directory if not exists
         run: mkdir -p ballerina/lib
       - name: Run Trivy vulnerability scanner
-        env:
-          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
-          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.23.0
         with:
-          scan-type: 'rootfs'
-          scan-ref: '${{ github.workspace.ballerina.lib }}/'
-          format: 'table'
-          timeout: '10m0s'
-          exit-code: '1'
-          scanners: "vuln"
+          scan-type: "rootfs"
+          scan-ref: "/github/workspace/ballerina/lib"
+          format: "table"
+          timeout: "10m0s"
+          exit-code: "1"
       - name: Set version env variable
         run: echo "VERSION=$((grep -w 'version' | cut -d= -f2) < gradle.properties | rev | cut --complement -d- -f1 | rev)" >> $GITHUB_ENV
       - name: Pre release dependency version update


### PR DESCRIPTION
## Purpose

$subject, please. We have encountered several issues in the master. We need to investigate it further. As we need to release the persist.sql, we revert to the 0.23.0 version

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Checked native-image compatibility
