### PR TITLE
Fix `MANY_TO_ONE` secondary `SELECT` to alias `SQL` column names for Ballerina field names

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "persist.sql"
-version = "1.7.3"
+version = "1.7.4"
 authors = ["Ballerina"]
 keywords = ["persist", "sql", "mysql", "mssql", "sql-server", "Vendor/Other", "Area/Database", "Type/Library"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-persist.sql"
@@ -15,8 +15,8 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "persist.sql-native"
-version = "1.7.3"
-path = "../native/build/libs/persist.sql-native-1.7.3.jar"
+version = "1.7.4"
+path = "../native/build/libs/persist.sql-native-1.7.4-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "persist.sql-compiler-plugin"
 class = "io.ballerina.stdlib.persist.sql.compiler.PersistSqlCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/persist.sql-compiler-plugin-1.7.3.jar"
+path = "../compiler-plugin/build/libs/persist.sql-compiler-plugin-1.7.4-SNAPSHOT.jar"
 
 [[dependency]]
 path = "./lib/persist-native-1.6.0.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -44,7 +44,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.9.0"
+version = "2.9.3"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
@@ -54,7 +54,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "data.jsondata"
-version = "1.1.0"
+version = "1.1.3"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
@@ -76,7 +76,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.0"
+version = "2.14.9"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -123,7 +123,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "jwt"
-version = "2.15.0"
+version = "2.15.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "cache"},
@@ -252,7 +252,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.12.0"
+version = "2.12.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -264,7 +264,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.14.0"
+version = "2.14.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "cache"},
@@ -278,7 +278,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -286,7 +286,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "os"
-version = "1.10.0"
+version = "1.10.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -356,7 +356,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.6.0"
+version = "2.6.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
@@ -399,7 +399,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "h2.driver"
-version = "1.2.0"
+version = "1.2.1"
 scope = "testOnly"
 modules = [
 	{org = "ballerinax", packageName = "h2.driver", moduleName = "h2.driver"}
@@ -464,7 +464,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "mysql.driver"
-version = "1.8.0"
+version = "1.8.1"
 scope = "testOnly"
 modules = [
 	{org = "ballerinax", packageName = "mysql.driver", moduleName = "mysql.driver"}
@@ -473,7 +473,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "persist.sql"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "log"},
@@ -514,7 +514,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "postgresql.driver"
-version = "1.6.0"
+version = "1.6.3"
 scope = "testOnly"
 modules = [
 	{org = "ballerinax", packageName = "postgresql.driver", moduleName = "postgresql.driver"}

--- a/ballerina/sql_client.bal
+++ b/ballerina/sql_client.bal
@@ -406,8 +406,13 @@ public isolated client class SQLClient {
                 continue;
             }
 
-            string columnName = fieldMetadata.relation.refColumn ?: fieldMetadata.relation.refField;
-            columnNames.push(self.escape(columnName));
+            string refField = fieldMetadata.relation.refField;
+            string refColumn = fieldMetadata.relation.refColumn ?: refField;
+            if refColumn != refField {
+                columnNames.push(self.escape(refColumn) + " AS " + self.escape(refField));
+            } else {
+                columnNames.push(self.escape(refColumn));
+            }
         }
         return arrayToParameterizedQuery(columnNames);
     }

--- a/ballerina/tests/h2_hospital_tests.bal
+++ b/ballerina/tests/h2_hospital_tests.bal
@@ -379,31 +379,43 @@ function testPatientWithAppointmentsManyRelationColumnAliasH2() returns error? {
     int patientId = patientIds[0];
     _ = check h2DbHospital->/appointments.post([{id: 50, patientId: patientId, doctorId: 50, appointmentTime: {year: 2024, month: 3, day: 20, hour: 10, minute: 0}, status: "SCHEDULED", reason: "Routine check"}]);
 
-    // queryOne path: PatientWithRelations triggers MANY_TO_ONE secondary SELECT.
-    // patient_id column must be aliased to patientId for AppointmentOptionalized mapping to succeed.
-    PatientWithRelations patient = check h2DbHospital->/patients/[patientId].get();
-    AppointmentOptionalized[]? appts = patient.appointments;
-    test:assertTrue(appts is AppointmentOptionalized[], "appointments array should be populated");
-    test:assertEquals((<AppointmentOptionalized[]>appts).length(), 1);
-    test:assertEquals((<AppointmentOptionalized[]>appts)[0].patientId, patientId,
-        "patient_id column must be aliased to patientId in MANY_TO_ONE secondary SELECT");
+    error? testError = ();
+    do {
+        // queryOne path: PatientWithRelations triggers MANY_TO_ONE secondary SELECT.
+        // patient_id column must be aliased to patientId for AppointmentOptionalized mapping to succeed.
+        PatientWithRelations patient = check h2DbHospital->/patients/[patientId].get();
+        AppointmentOptionalized[]? appts = patient.appointments;
+        test:assertTrue(appts is AppointmentOptionalized[], "appointments array should be populated");
+        test:assertEquals((<AppointmentOptionalized[]>appts).length(), 1);
+        test:assertEquals((<AppointmentOptionalized[]>appts)[0].patientId, patientId,
+            "patient_id column must be aliased to patientId in MANY_TO_ONE secondary SELECT");
 
-    // stream path: same getManyRelations call is exercised per row via PersistSQLStream.next()
-    stream<PatientWithRelations, persist:Error?> patientStream = h2DbHospital->/patients.get();
-    PatientWithRelations[] patients = check from PatientWithRelations p in patientStream
-        where p.name == "Alias Test Patient"
-        select p;
-    AppointmentOptionalized[]? appointments = patients[0].appointments;
-    if appointments is () {
-        test:assertFail("appointments should be populated in stream path");
+        // stream path: same getManyRelations call is exercised per row via PersistSQLStream.next()
+        stream<PatientWithRelations, persist:Error?> patientStream = h2DbHospital->/patients.get();
+        PatientWithRelations[] patients = check from PatientWithRelations p in patientStream
+            where p.name == "Alias Test Patient"
+            select p;
+        if patients.length() != 1 {
+            check error("Expected exactly 1 patient named 'Alias Test Patient' in stream path, got " + patients.length().toString());
+        }
+        AppointmentOptionalized[]? appointments = patients[0].appointments;
+        if appointments is () {
+            test:assertFail("appointments should be populated in stream path");
+        }
+        if appointments.length() != 1 {
+            test:assertFail("there should be 1 appointment in stream path");
+        }
+        test:assertEquals(appointments[0].patientId, patientId,
+            "patient_id column must be aliased to patientId in stream path");
+    } on fail error e {
+        testError = e;
     }
-    if appointments.length() != 1 {
-        test:assertFail("there should be 1 appointment in stream path");
-    }
-    test:assertEquals(appointments[0].patientId, patientId,
-        "patient_id column must be aliased to patientId in stream path");
 
+    _ = check h2DbHospital->/appointments/[50].delete();
+    _ = check h2DbHospital->/doctors/[50].delete();
+    _ = check h2DbHospital->/patients/[patientId].delete();
     check h2DbHospital.close();
+    return testError;
 }
 
 @test:Config {
@@ -413,40 +425,46 @@ function testPatientWithAppointmentsManyRelationColumnAliasH2() returns error? {
 function testDoctorWithAppointmentsManyRelationColumnAliasH2() returns error? {
     H2HospitalClient h2DbHospital = check new ();
 
-    // queryOne path: DoctorWithRelations triggers MANY_TO_ONE secondary SELECT.
-    // The appointments table's patient_id column must be aliased to patientId.
-    DoctorWithRelations doctor = check h2DbHospital->/doctors/[50].get();
-    AppointmentOptionalized[]? appts = doctor.appointments;
-    test:assertTrue(appts is AppointmentOptionalized[], "doctor appointments should be populated");
-    test:assertEquals((<AppointmentOptionalized[]>appts).length(), 1);
-    test:assertNotEquals((<AppointmentOptionalized[]>appts)[0].patientId, (),
-        "patientId should be mapped from patient_id column in doctor's appointment list");
+    _ = check h2DbHospital->/doctors.post([{id: 50, name: "Dr. Alias Test", specialty: "Neurologist", phoneNumber: "0779990000", salary: 25000}]);
+    int[] patientIds = check h2DbHospital->/patients.post([{name: "Alias Test Patient", age: 28, phoneNumber: "0779990001", gender: "FEMALE", address: "10, Test St, Colombo 03"}]);
+    int patientId = patientIds[0];
+    _ = check h2DbHospital->/appointments.post([{id: 50, patientId: patientId, doctorId: 50, appointmentTime: {year: 2024, month: 3, day: 20, hour: 10, minute: 0}, status: "SCHEDULED", reason: "Routine check"}]);
 
-    // stream path
-    stream<DoctorWithRelations, persist:Error?> doctorStream = h2DbHospital->/doctors.get();
-    DoctorWithRelations[] doctors = check from DoctorWithRelations d in doctorStream
-        where d.name == "Dr. Alias Test"
-        select d;
-    test:assertEquals(doctors.length(), 1);
-    AppointmentOptionalized[]? appointments = doctors[0].appointments;
-    if appointments is () {
-        test:assertFail("appointments should be populated in stream path");
-    }
-    if appointments.length() != 1 {
-        test:assertFail("there should be 1 appointment in stream path");
-    }
-    test:assertNotEquals(appointments[0].patientId, (),
-        "patientId should be correctly mapped in doctor stream path");
+    error? testError = ();
+    do {
+        // queryOne path: DoctorWithRelations triggers MANY_TO_ONE secondary SELECT.
+        // The appointments table's patient_id column must be aliased to patientId.
+        DoctorWithRelations doctor = check h2DbHospital->/doctors/[50].get();
+        AppointmentOptionalized[]? appts = doctor.appointments;
+        test:assertTrue(appts is AppointmentOptionalized[], "doctor appointments should be populated");
+        test:assertEquals((<AppointmentOptionalized[]>appts).length(), 1);
+        test:assertNotEquals((<AppointmentOptionalized[]>appts)[0].patientId, (),
+            "patientId should be mapped from patient_id column in doctor's appointment list");
 
-    // cleanup
+        // stream path
+        stream<DoctorWithRelations, persist:Error?> doctorStream = h2DbHospital->/doctors.get();
+        DoctorWithRelations[] doctors = check from DoctorWithRelations d in doctorStream
+            where d.name == "Dr. Alias Test"
+            select d;
+        if doctors.length() != 1 {
+            check error("Expected exactly 1 doctor named 'Dr. Alias Test' in stream path, got " + doctors.length().toString());
+        }
+        AppointmentOptionalized[]? appointments = doctors[0].appointments;
+        if appointments is () {
+            test:assertFail("appointments should be populated in stream path");
+        }
+        if appointments.length() != 1 {
+            test:assertFail("there should be 1 appointment in stream path");
+        }
+        test:assertNotEquals(appointments[0].patientId, (),
+            "patientId should be correctly mapped in doctor stream path");
+    } on fail error e {
+        testError = e;
+    }
+
     _ = check h2DbHospital->/appointments/[50].delete();
     _ = check h2DbHospital->/doctors/[50].delete();
-    stream<Patient, persist:Error?> patientStream = h2DbHospital->/patients.get();
-    Patient[] patients = check from Patient p in patientStream
-        where p.name == "Alias Test Patient"
-        select p;
-    foreach Patient p in patients {
-        _ = check h2DbHospital->/patients/[p.id].delete();
-    }
+    _ = check h2DbHospital->/patients/[patientId].delete();
     check h2DbHospital.close();
+    return testError;
 }

--- a/ballerina/tests/h2_hospital_tests.bal
+++ b/ballerina/tests/h2_hospital_tests.bal
@@ -361,3 +361,92 @@ function testDeleteDoctorH2() returns error? {
         test:assertFail("Patient should be deleted");
     }
 }
+
+// Regression tests for: MANY_TO_ONE secondary SELECT with snake_case columns (refColumn != refField).
+// The appointment table uses patient_id (SQL column) which maps to patientId (Ballerina field).
+// Without the fix in getManyRelationColumnNames, this caused:
+//   "No mapping field found for SQL table column 'patient_id' in the record type 'AppointmentOptionalized'"
+
+@test:Config {
+    groups: ["annotation", "h2"],
+    dependsOn: [testDeletePatientH2, testDeleteDoctorH2]
+}
+function testPatientWithAppointmentsManyRelationColumnAliasH2() returns error? {
+    H2HospitalClient h2DbHospital = check new ();
+
+    _ = check h2DbHospital->/doctors.post([{id: 50, name: "Dr. Alias Test", specialty: "Neurologist", phoneNumber: "0779990000", salary: 25000}]);
+    int[] patientIds = check h2DbHospital->/patients.post([{name: "Alias Test Patient", age: 28, phoneNumber: "0779990001", gender: "FEMALE", address: "10, Test St, Colombo 03"}]);
+    int patientId = patientIds[0];
+    _ = check h2DbHospital->/appointments.post([{id: 50, patientId: patientId, doctorId: 50, appointmentTime: {year: 2024, month: 3, day: 20, hour: 10, minute: 0}, status: "SCHEDULED", reason: "Routine check"}]);
+
+    // queryOne path: PatientWithRelations triggers MANY_TO_ONE secondary SELECT.
+    // patient_id column must be aliased to patientId for AppointmentOptionalized mapping to succeed.
+    PatientWithRelations patient = check h2DbHospital->/patients/[patientId].get();
+    AppointmentOptionalized[]? appts = patient.appointments;
+    test:assertTrue(appts is AppointmentOptionalized[], "appointments array should be populated");
+    test:assertEquals((<AppointmentOptionalized[]>appts).length(), 1);
+    test:assertEquals((<AppointmentOptionalized[]>appts)[0].patientId, patientId,
+        "patient_id column must be aliased to patientId in MANY_TO_ONE secondary SELECT");
+
+    // stream path: same getManyRelations call is exercised per row via PersistSQLStream.next()
+    stream<PatientWithRelations, persist:Error?> patientStream = h2DbHospital->/patients.get();
+    PatientWithRelations[] patients = check from PatientWithRelations p in patientStream
+        where p.name == "Alias Test Patient"
+        select p;
+    AppointmentOptionalized[]? appointments = patients[0].appointments;
+    if appointments is () {
+        test:assertFail("appointments should be populated in stream path");
+    }
+    if appointments.length() != 1 {
+        test:assertFail("there should be 1 appointment in stream path");
+    }
+    test:assertEquals(appointments[0].patientId, patientId,
+        "patient_id column must be aliased to patientId in stream path");
+
+    check h2DbHospital.close();
+}
+
+@test:Config {
+    groups: ["annotation", "h2"],
+    dependsOn: [testPatientWithAppointmentsManyRelationColumnAliasH2]
+}
+function testDoctorWithAppointmentsManyRelationColumnAliasH2() returns error? {
+    H2HospitalClient h2DbHospital = check new ();
+
+    // queryOne path: DoctorWithRelations triggers MANY_TO_ONE secondary SELECT.
+    // The appointments table's patient_id column must be aliased to patientId.
+    DoctorWithRelations doctor = check h2DbHospital->/doctors/[50].get();
+    AppointmentOptionalized[]? appts = doctor.appointments;
+    test:assertTrue(appts is AppointmentOptionalized[], "doctor appointments should be populated");
+    test:assertEquals((<AppointmentOptionalized[]>appts).length(), 1);
+    test:assertNotEquals((<AppointmentOptionalized[]>appts)[0].patientId, (),
+        "patientId should be mapped from patient_id column in doctor's appointment list");
+
+    // stream path
+    stream<DoctorWithRelations, persist:Error?> doctorStream = h2DbHospital->/doctors.get();
+    DoctorWithRelations[] doctors = check from DoctorWithRelations d in doctorStream
+        where d.name == "Dr. Alias Test"
+        select d;
+    test:assertEquals(doctors.length(), 1);
+    AppointmentOptionalized[]? appointments = doctors[0].appointments;
+    if appointments is () {
+        test:assertFail("appointments should be populated in stream path");
+    }
+    if appointments.length() != 1 {
+        test:assertFail("there should be 1 appointment in stream path");
+    }
+    test:assertNotEquals(appointments[0].patientId, (),
+        "patientId should be correctly mapped in doctor stream path");
+
+    // cleanup
+    _ = check h2DbHospital->/appointments/[50].delete();
+    _ = check h2DbHospital->/doctors/[50].delete();
+    stream<Patient, persist:Error?> patientStream = h2DbHospital->/patients.get();
+    Patient[] patients = check from Patient p in patientStream
+        where p.name == "Alias Test Patient"
+        select p;
+    foreach Patient p in patients {
+        _ = check h2DbHospital->/patients/[p.id].delete();
+    }
+    check h2DbHospital.close();
+}

--- a/ballerina/tests/mssql_hospital_tests.bal
+++ b/ballerina/tests/mssql_hospital_tests.bal
@@ -356,3 +356,86 @@ function testDeleteDoctorMsSql() returns error? {
             test:assertFail("Patient should be deleted");
     }
 }
+
+@test:Config {
+    groups: ["annotation", "mssql"],
+    dependsOn: [testDeletePatientMsSql, testDeleteDoctorMsSql]
+}
+function testPatientWithAppointmentsManyRelationColumnAliasMsSql() returns error? {
+    MsSqlHospitalClient mssqlDbHospital = check new ();
+
+    _ = check mssqlDbHospital->/doctors.post([{id: 50, name: "Dr. Alias Test", specialty: "Neurologist", phoneNumber: "0779990000", salary: 25000}]);
+    _ = check mssqlDbHospital->/patients.post([{name: "Alias Test Patient", age: 28, phoneNumber: "0779990001", gender: "FEMALE", address: "10, Test St, Colombo 03"}]);
+    // MSSQL IDENTITY columns do not return lastInsertId via batchExecute — query to get the generated ID.
+    stream<Patient, persist:Error?> pStream = mssqlDbHospital->/patients.get();
+    Patient[] pFound = check from Patient p in pStream where p.name == "Alias Test Patient" select p;
+    int patientId = pFound[0].id;
+    _ = check mssqlDbHospital->/appointments.post([{id: 50, patientId: patientId, doctorId: 50, appointmentTime: {year: 2024, month: 3, day: 20, hour: 10, minute: 0}, status: "SCHEDULED", reason: "Routine check"}]);
+
+    // queryOne: PatientWithRelations triggers MANY_TO_ONE secondary SELECT.
+    // patient_id column must be aliased to patientId for AppointmentOptionalized mapping to succeed.
+    PatientWithRelations patient = check mssqlDbHospital->/patients/[patientId].get();
+    AppointmentOptionalized[]? appts = patient.appointments;
+    test:assertTrue(appts is AppointmentOptionalized[], "appointments array should be populated");
+    test:assertEquals((<AppointmentOptionalized[]>appts).length(), 1);
+    test:assertEquals((<AppointmentOptionalized[]>appts)[0].patientId, patientId,
+        "patient_id column must be aliased to patientId in MANY_TO_ONE secondary SELECT");
+
+    // stream path
+    stream<PatientWithRelations, persist:Error?> patientStream = mssqlDbHospital->/patients.get();
+    PatientWithRelations[] patients = check from PatientWithRelations p in patientStream
+        where p.name == "Alias Test Patient"
+        select p;
+    AppointmentOptionalized[]? appointments = patients[0].appointments;
+    if appointments is () {
+        test:assertFail("appointments array should be populated in stream path");
+    }
+    if appointments.length() != 1 {
+        test:assertFail("there should be 1 appointment in stream path");
+    }
+    test:assertEquals(appointments[0].patientId, patientId,
+        "patient_id column must be aliased to patientId in stream path");
+
+    check mssqlDbHospital.close();
+}
+
+@test:Config {
+    groups: ["annotation", "mssql"],
+    dependsOn: [testPatientWithAppointmentsManyRelationColumnAliasMsSql]
+}
+function testDoctorWithAppointmentsManyRelationColumnAliasMsSql() returns error? {
+    MsSqlHospitalClient mssqlDbHospital = check new ();
+
+    DoctorWithRelations doctor = check mssqlDbHospital->/doctors/[50].get();
+    AppointmentOptionalized[]? appts = doctor.appointments;
+    test:assertTrue(appts is AppointmentOptionalized[], "doctor appointments should be populated");
+    test:assertEquals((<AppointmentOptionalized[]>appts).length(), 1);
+    test:assertNotEquals((<AppointmentOptionalized[]>appts)[0].patientId, (),
+        "patientId should be mapped from patient_id column in doctor's appointment list");
+
+    stream<DoctorWithRelations, persist:Error?> doctorStream = mssqlDbHospital->/doctors.get();
+    DoctorWithRelations[] doctors = check from DoctorWithRelations d in doctorStream
+        where d.name == "Dr. Alias Test"
+        select d;
+    test:assertEquals(doctors.length(), 1);
+    AppointmentOptionalized[]? appointments = doctors[0].appointments;
+    if appointments is () {
+        test:assertFail("appointments should be populated in stream path");
+    }
+    if appointments.length() != 1 {
+        test:assertFail("there should be 1 appointment in stream path");
+    }
+    test:assertNotEquals(appointments[0].patientId, (),
+        "patientId should be correctly mapped in doctor stream path");
+
+    _ = check mssqlDbHospital->/appointments/[50].delete();
+    _ = check mssqlDbHospital->/doctors/[50].delete();
+    stream<Patient, persist:Error?> patientStream = mssqlDbHospital->/patients.get();
+    Patient[] patients = check from Patient p in patientStream
+        where p.name == "Alias Test Patient"
+        select p;
+    foreach Patient p in patients {
+        _ = check mssqlDbHospital->/patients/[p.id].delete();
+    }
+    check mssqlDbHospital.close();
+}

--- a/ballerina/tests/mssql_hospital_tests.bal
+++ b/ballerina/tests/mssql_hospital_tests.bal
@@ -369,34 +369,53 @@ function testPatientWithAppointmentsManyRelationColumnAliasMsSql() returns error
     // MSSQL IDENTITY columns do not return lastInsertId via batchExecute — query to get the generated ID.
     stream<Patient, persist:Error?> pStream = mssqlDbHospital->/patients.get();
     Patient[] pFound = check from Patient p in pStream where p.name == "Alias Test Patient" select p;
+    if pFound.length() == 0 {
+        check mssqlDbHospital.close();
+        return error("Could not find seeded patient 'Alias Test Patient'");
+    }
     int patientId = pFound[0].id;
     _ = check mssqlDbHospital->/appointments.post([{id: 50, patientId: patientId, doctorId: 50, appointmentTime: {year: 2024, month: 3, day: 20, hour: 10, minute: 0}, status: "SCHEDULED", reason: "Routine check"}]);
 
-    // queryOne: PatientWithRelations triggers MANY_TO_ONE secondary SELECT.
-    // patient_id column must be aliased to patientId for AppointmentOptionalized mapping to succeed.
-    PatientWithRelations patient = check mssqlDbHospital->/patients/[patientId].get();
-    AppointmentOptionalized[]? appts = patient.appointments;
-    test:assertTrue(appts is AppointmentOptionalized[], "appointments array should be populated");
-    test:assertEquals((<AppointmentOptionalized[]>appts).length(), 1);
-    test:assertEquals((<AppointmentOptionalized[]>appts)[0].patientId, patientId,
-        "patient_id column must be aliased to patientId in MANY_TO_ONE secondary SELECT");
+    error? testError = ();
+    do {
+        // queryOne: PatientWithRelations triggers MANY_TO_ONE secondary SELECT.
+        // patient_id column must be aliased to patientId for AppointmentOptionalized mapping to succeed.
+        PatientWithRelations patient = check mssqlDbHospital->/patients/[patientId].get();
+        AppointmentOptionalized[]? appts = patient.appointments;
+        if appts is AppointmentOptionalized[] {
+            test:assertEquals(appts.length(), 1);
+            test:assertEquals(appts[0].patientId, patientId,
+                "patient_id column must be aliased to patientId in MANY_TO_ONE secondary SELECT");
+        } else {
+            test:assertFail("appointments array should be populated");
+        }
 
-    // stream path
-    stream<PatientWithRelations, persist:Error?> patientStream = mssqlDbHospital->/patients.get();
-    PatientWithRelations[] patients = check from PatientWithRelations p in patientStream
-        where p.name == "Alias Test Patient"
-        select p;
-    AppointmentOptionalized[]? appointments = patients[0].appointments;
-    if appointments is () {
-        test:assertFail("appointments array should be populated in stream path");
+        // stream path
+        stream<PatientWithRelations, persist:Error?> patientStream = mssqlDbHospital->/patients.get();
+        PatientWithRelations[] patients = check from PatientWithRelations p in patientStream
+            where p.name == "Alias Test Patient"
+            select p;
+        if patients.length() != 1 {
+            check error("Expected exactly 1 patient named 'Alias Test Patient' in stream path, got " + patients.length().toString());
+        }
+        AppointmentOptionalized[]? appointments = patients[0].appointments;
+        if appointments is () {
+            test:assertFail("appointments array should be populated in stream path");
+        }
+        if appointments.length() != 1 {
+            test:assertFail("there should be 1 appointment in stream path");
+        }
+        test:assertEquals(appointments[0].patientId, patientId,
+            "patient_id column must be aliased to patientId in stream path");
+    } on fail error e {
+        testError = e;
     }
-    if appointments.length() != 1 {
-        test:assertFail("there should be 1 appointment in stream path");
-    }
-    test:assertEquals(appointments[0].patientId, patientId,
-        "patient_id column must be aliased to patientId in stream path");
 
+    _ = check mssqlDbHospital->/appointments/[50].delete();
+    _ = check mssqlDbHospital->/doctors/[50].delete();
+    _ = check mssqlDbHospital->/patients/[patientId].delete();
     check mssqlDbHospital.close();
+    return testError;
 }
 
 @test:Config {
@@ -406,36 +425,52 @@ function testPatientWithAppointmentsManyRelationColumnAliasMsSql() returns error
 function testDoctorWithAppointmentsManyRelationColumnAliasMsSql() returns error? {
     MsSqlHospitalClient mssqlDbHospital = check new ();
 
-    DoctorWithRelations doctor = check mssqlDbHospital->/doctors/[50].get();
-    AppointmentOptionalized[]? appts = doctor.appointments;
-    test:assertTrue(appts is AppointmentOptionalized[], "doctor appointments should be populated");
-    test:assertEquals((<AppointmentOptionalized[]>appts).length(), 1);
-    test:assertNotEquals((<AppointmentOptionalized[]>appts)[0].patientId, (),
-        "patientId should be mapped from patient_id column in doctor's appointment list");
+    _ = check mssqlDbHospital->/doctors.post([{id: 50, name: "Dr. Alias Test", specialty: "Neurologist", phoneNumber: "0779990000", salary: 25000}]);
+    _ = check mssqlDbHospital->/patients.post([{name: "Alias Test Patient", age: 28, phoneNumber: "0779990001", gender: "FEMALE", address: "10, Test St, Colombo 03"}]);
+    stream<Patient, persist:Error?> pStream = mssqlDbHospital->/patients.get();
+    Patient[] pFound = check from Patient p in pStream where p.name == "Alias Test Patient" select p;
+    if pFound.length() == 0 {
+        check mssqlDbHospital.close();
+        return error("Could not find seeded patient 'Alias Test Patient'");
+    }
+    int patientId = pFound[0].id;
+    _ = check mssqlDbHospital->/appointments.post([{id: 50, patientId: patientId, doctorId: 50, appointmentTime: {year: 2024, month: 3, day: 20, hour: 10, minute: 0}, status: "SCHEDULED", reason: "Routine check"}]);
 
-    stream<DoctorWithRelations, persist:Error?> doctorStream = mssqlDbHospital->/doctors.get();
-    DoctorWithRelations[] doctors = check from DoctorWithRelations d in doctorStream
-        where d.name == "Dr. Alias Test"
-        select d;
-    test:assertEquals(doctors.length(), 1);
-    AppointmentOptionalized[]? appointments = doctors[0].appointments;
-    if appointments is () {
-        test:assertFail("appointments should be populated in stream path");
+    error? testError = ();
+    do {
+        DoctorWithRelations doctor = check mssqlDbHospital->/doctors/[50].get();
+        AppointmentOptionalized[]? appts = doctor.appointments;
+        if appts is AppointmentOptionalized[] {
+            test:assertEquals(appts.length(), 1);
+            test:assertEquals(appts[0].patientId, patientId,
+                "patientId should be mapped from patient_id column in doctor's appointment list");
+        } else {
+            test:assertFail("doctor appointments should be populated");
+        }
+
+        stream<DoctorWithRelations, persist:Error?> doctorStream = mssqlDbHospital->/doctors.get();
+        DoctorWithRelations[] doctors = check from DoctorWithRelations d in doctorStream
+            where d.name == "Dr. Alias Test"
+            select d;
+        if doctors.length() != 1 {
+            check error("Expected exactly 1 doctor named 'Dr. Alias Test' in stream path, got " + doctors.length().toString());
+        }
+        AppointmentOptionalized[]? appointments = doctors[0].appointments;
+        if appointments is () {
+            test:assertFail("appointments should be populated in stream path");
+        }
+        if appointments.length() != 1 {
+            test:assertFail("there should be 1 appointment in stream path");
+        }
+        test:assertEquals(appointments[0].patientId, patientId,
+            "patientId should be correctly mapped in doctor stream path");
+    } on fail error e {
+        testError = e;
     }
-    if appointments.length() != 1 {
-        test:assertFail("there should be 1 appointment in stream path");
-    }
-    test:assertNotEquals(appointments[0].patientId, (),
-        "patientId should be correctly mapped in doctor stream path");
 
     _ = check mssqlDbHospital->/appointments/[50].delete();
     _ = check mssqlDbHospital->/doctors/[50].delete();
-    stream<Patient, persist:Error?> patientStream = mssqlDbHospital->/patients.get();
-    Patient[] patients = check from Patient p in patientStream
-        where p.name == "Alias Test Patient"
-        select p;
-    foreach Patient p in patients {
-        _ = check mssqlDbHospital->/patients/[p.id].delete();
-    }
+    _ = check mssqlDbHospital->/patients/[patientId].delete();
     check mssqlDbHospital.close();
+    return testError;
 }

--- a/ballerina/tests/mysql_hospital_tests.bal
+++ b/ballerina/tests/mysql_hospital_tests.bal
@@ -385,6 +385,9 @@ function testPatientWithAppointmentsManyRelationColumnAliasMySql() returns error
     PatientWithRelations[] patients = check from PatientWithRelations p in patientStream
         where p.name == "Alias Test Patient"
         select p;
+    if patients.length() != 1 {
+        return error("Expected exactly 1 patient named 'Alias Test Patient' in stream path, got " + patients.length().toString());
+    }
     AppointmentOptionalized[]? apptsFromStream = patients[0].appointments;
     if apptsFromStream is () {
         test:assertFail("appointments array should be populated in stream path");
@@ -416,7 +419,9 @@ function testDoctorWithAppointmentsManyRelationColumnAliasMySql() returns error?
     DoctorWithRelations[] doctors = check from DoctorWithRelations d in doctorStream
         where d.name == "Dr. Alias Test"
         select d;
-    test:assertEquals(doctors.length(), 1);
+    if doctors.length() != 1 {
+        return error("Expected exactly 1 doctor named 'Dr. Alias Test' in stream path, got " + doctors.length().toString());
+    }
     AppointmentOptionalized[]? appointments = doctors[0].appointments;
     if appointments is () {
         test:assertFail("appointments should be populated in stream path");

--- a/ballerina/tests/mysql_hospital_tests.bal
+++ b/ballerina/tests/mysql_hospital_tests.bal
@@ -358,3 +358,83 @@ function testDeleteDoctorMySql() returns error? {
             test:assertFail("Patient should be deleted");
     }
 }
+
+@test:Config {
+    groups: ["annotation", "mysql"],
+    dependsOn: [testDeletePatientMySql, testDeleteDoctorMySql]
+}
+function testPatientWithAppointmentsManyRelationColumnAliasMySql() returns error? {
+    MySqlHospitalClient mysqlDbHospital = check new ();
+
+    _ = check mysqlDbHospital->/doctors.post([{id: 50, name: "Dr. Alias Test", specialty: "Neurologist", phoneNumber: "0779990000", salary: 25000}]);
+    int[] patientIds = check mysqlDbHospital->/patients.post([{name: "Alias Test Patient", age: 28, phoneNumber: "0779990001", gender: "FEMALE", address: "10, Test St, Colombo 03"}]);
+    int patientId = patientIds[0];
+    _ = check mysqlDbHospital->/appointments.post([{id: 50, patientId: patientId, doctorId: 50, appointmentTime: {year: 2024, month: 3, day: 20, hour: 10, minute: 0}, status: "SCHEDULED", reason: "Routine check"}]);
+
+    // queryOne: PatientWithRelations triggers MANY_TO_ONE secondary SELECT.
+    // patient_id column must be aliased to patientId for AppointmentOptionalized mapping to succeed.
+    PatientWithRelations patient = check mysqlDbHospital->/patients/[patientId].get();
+    AppointmentOptionalized[]? appts = patient.appointments;
+    test:assertTrue(appts is AppointmentOptionalized[], "appointments array should be populated");
+    test:assertEquals((<AppointmentOptionalized[]>appts).length(), 1);
+    test:assertEquals((<AppointmentOptionalized[]>appts)[0].patientId, patientId,
+        "patient_id column must be aliased to patientId in MANY_TO_ONE secondary SELECT");
+
+    // stream path
+    stream<PatientWithRelations, persist:Error?> patientStream = mysqlDbHospital->/patients.get();
+    PatientWithRelations[] patients = check from PatientWithRelations p in patientStream
+        where p.name == "Alias Test Patient"
+        select p;
+    AppointmentOptionalized[]? apptsFromStream = patients[0].appointments;
+    if apptsFromStream is () {
+        test:assertFail("appointments array should be populated in stream path");
+    }
+    if apptsFromStream.length() != 1 {
+        test:assertFail("there should be 1 appointment in stream path");
+    }
+    test:assertEquals(apptsFromStream[0].patientId, patientId,
+        "patient_id column must be aliased to patientId in stream path");
+
+    check mysqlDbHospital.close();
+}
+
+@test:Config {
+    groups: ["annotation", "mysql"],
+    dependsOn: [testPatientWithAppointmentsManyRelationColumnAliasMySql]
+}
+function testDoctorWithAppointmentsManyRelationColumnAliasMySql() returns error? {
+    MySqlHospitalClient mysqlDbHospital = check new ();
+
+    DoctorWithRelations doctor = check mysqlDbHospital->/doctors/[50].get();
+    AppointmentOptionalized[]? appts = doctor.appointments;
+    test:assertTrue(appts is AppointmentOptionalized[], "doctor appointments should be populated");
+    test:assertEquals((<AppointmentOptionalized[]>appts).length(), 1);
+    test:assertNotEquals((<AppointmentOptionalized[]>appts)[0].patientId, (),
+        "patientId should be mapped from patient_id column in doctor's appointment list");
+
+    stream<DoctorWithRelations, persist:Error?> doctorStream = mysqlDbHospital->/doctors.get();
+    DoctorWithRelations[] doctors = check from DoctorWithRelations d in doctorStream
+        where d.name == "Dr. Alias Test"
+        select d;
+    test:assertEquals(doctors.length(), 1);
+    AppointmentOptionalized[]? appointments = doctors[0].appointments;
+    if appointments is () {
+        test:assertFail("appointments should be populated in stream path");
+    }
+    if appointments.length() != 1 {
+        test:assertFail("there should be 1 appointment in stream path");
+    }
+    test:assertNotEquals(appointments[0].patientId, (),
+        "patientId should be correctly mapped in doctor stream path");
+
+    _ = check mysqlDbHospital->/appointments/[50].delete();
+    _ = check mysqlDbHospital->/doctors/[50].delete();
+    stream<Patient, persist:Error?> patientStream = mysqlDbHospital->/patients.get();
+    Patient[] patients = check from Patient p in patientStream
+        where p.name == "Alias Test Patient"
+        select p;
+    foreach Patient p in patients {
+        _ = check mysqlDbHospital->/patients/[p.id].delete();
+    }
+    check mysqlDbHospital.close();
+}

--- a/ballerina/tests/postgresql_hospital_tests.bal
+++ b/ballerina/tests/postgresql_hospital_tests.bal
@@ -355,3 +355,86 @@ function testDeleteDoctorPostgreSql() returns error? {
             test:assertFail("Patient should be deleted");
     }
 }
+
+@test:Config {
+    groups: ["annotation", "postgresql"],
+    dependsOn: [testDeletePatientPostgreSql, testDeleteDoctorPostgreSql]
+}
+function testPatientWithAppointmentsManyRelationColumnAliasPostgreSql() returns error? {
+    PostgreSqlHospitalClient postgresSqlDbHospital = check new ();
+
+    _ = check postgresSqlDbHospital->/doctors.post([{id: 50, name: "Dr. Alias Test", specialty: "Neurologist", phoneNumber: "0779990000", salary: 25000}]);
+    _ = check postgresSqlDbHospital->/patients.post([{name: "Alias Test Patient", age: 28, phoneNumber: "0779990001", gender: "FEMALE", address: "10, Test St, Colombo 03"}]);
+    // PostgreSQL sequences may not return lastInsertId via batchExecute — query to get the generated ID.
+    stream<Patient, persist:Error?> pStream = postgresSqlDbHospital->/patients.get();
+    Patient[] pFound = check from Patient p in pStream where p.name == "Alias Test Patient" select p;
+    int patientId = pFound[0].id;
+    _ = check postgresSqlDbHospital->/appointments.post([{id: 50, patientId: patientId, doctorId: 50, appointmentTime: {year: 2024, month: 3, day: 20, hour: 10, minute: 0}, status: "SCHEDULED", reason: "Routine check"}]);
+
+    // queryOne: PatientWithRelations triggers MANY_TO_ONE secondary SELECT.
+    // patient_id column must be aliased to patientId for AppointmentOptionalized mapping to succeed.
+    PatientWithRelations patient = check postgresSqlDbHospital->/patients/[patientId].get();
+    AppointmentOptionalized[]? appts = patient.appointments;
+    test:assertTrue(appts is AppointmentOptionalized[], "appointments array should be populated");
+    test:assertEquals((<AppointmentOptionalized[]>appts).length(), 1);
+    test:assertEquals((<AppointmentOptionalized[]>appts)[0].patientId, patientId,
+        "patient_id column must be aliased to patientId in MANY_TO_ONE secondary SELECT");
+
+    // stream path
+    stream<PatientWithRelations, persist:Error?> patientStream = postgresSqlDbHospital->/patients.get();
+    PatientWithRelations[] patients = check from PatientWithRelations p in patientStream
+        where p.name == "Alias Test Patient"
+        select p;
+    AppointmentOptionalized[]? apptsFromStream = patients[0].appointments;
+    if apptsFromStream is () {
+        test:assertFail("appointments array should be populated in stream path");
+    }
+    if apptsFromStream.length() != 1 {
+        test:assertFail("there should be 1 appointment in stream path");
+    }
+    test:assertEquals(apptsFromStream[0].patientId, patientId,
+        "patient_id column must be aliased to patientId in stream path");
+
+    check postgresSqlDbHospital.close();
+}
+
+@test:Config {
+    groups: ["annotation", "postgresql"],
+    dependsOn: [testPatientWithAppointmentsManyRelationColumnAliasPostgreSql]
+}
+function testDoctorWithAppointmentsManyRelationColumnAliasPostgreSql() returns error? {
+    PostgreSqlHospitalClient postgresSqlDbHospital = check new ();
+
+    DoctorWithRelations doctor = check postgresSqlDbHospital->/doctors/[50].get();
+    AppointmentOptionalized[]? appts = doctor.appointments;
+    test:assertTrue(appts is AppointmentOptionalized[], "doctor appointments should be populated");
+    test:assertEquals((<AppointmentOptionalized[]>appts).length(), 1);
+    test:assertNotEquals((<AppointmentOptionalized[]>appts)[0].patientId, (),
+        "patientId should be mapped from patient_id column in doctor's appointment list");
+
+    stream<DoctorWithRelations, persist:Error?> doctorStream = postgresSqlDbHospital->/doctors.get();
+    DoctorWithRelations[] doctors = check from DoctorWithRelations d in doctorStream
+        where d.name == "Dr. Alias Test"
+        select d;
+    test:assertEquals(doctors.length(), 1);
+    AppointmentOptionalized[]? appointments = doctors[0].appointments;
+    if appointments is () {
+        test:assertFail("appointments should be populated in stream path");
+    }
+    if appointments.length() != 1 {
+        test:assertFail("there should be 1 appointment in stream path");
+    }
+    test:assertNotEquals(appointments[0].patientId, (),
+        "patientId should be correctly mapped in doctor stream path");
+
+    _ = check postgresSqlDbHospital->/appointments/[50].delete();
+    _ = check postgresSqlDbHospital->/doctors/[50].delete();
+    stream<Patient, persist:Error?> patientStream = postgresSqlDbHospital->/patients.get();
+    Patient[] patients = check from Patient p in patientStream
+        where p.name == "Alias Test Patient"
+        select p;
+    foreach Patient p in patients {
+        _ = check postgresSqlDbHospital->/patients/[p.id].delete();
+    }
+    check postgresSqlDbHospital.close();
+}

--- a/ballerina/tests/postgresql_hospital_tests.bal
+++ b/ballerina/tests/postgresql_hospital_tests.bal
@@ -365,37 +365,50 @@ function testPatientWithAppointmentsManyRelationColumnAliasPostgreSql() returns 
 
     _ = check postgresSqlDbHospital->/doctors.post([{id: 50, name: "Dr. Alias Test", specialty: "Neurologist", phoneNumber: "0779990000", salary: 25000}]);
     _ = check postgresSqlDbHospital->/patients.post([{name: "Alias Test Patient", age: 28, phoneNumber: "0779990001", gender: "FEMALE", address: "10, Test St, Colombo 03"}]);
-    // PostgreSQL sequences may not return lastInsertId via batchExecute — query to get the generated ID.
-    stream<Patient, persist:Error?> pStream = postgresSqlDbHospital->/patients.get();
-    Patient[] pFound = check from Patient p in pStream where p.name == "Alias Test Patient" select p;
-    int patientId = pFound[0].id;
-    _ = check postgresSqlDbHospital->/appointments.post([{id: 50, patientId: patientId, doctorId: 50, appointmentTime: {year: 2024, month: 3, day: 20, hour: 10, minute: 0}, status: "SCHEDULED", reason: "Routine check"}]);
 
-    // queryOne: PatientWithRelations triggers MANY_TO_ONE secondary SELECT.
-    // patient_id column must be aliased to patientId for AppointmentOptionalized mapping to succeed.
-    PatientWithRelations patient = check postgresSqlDbHospital->/patients/[patientId].get();
-    AppointmentOptionalized[]? appts = patient.appointments;
-    test:assertTrue(appts is AppointmentOptionalized[], "appointments array should be populated");
-    test:assertEquals((<AppointmentOptionalized[]>appts).length(), 1);
-    test:assertEquals((<AppointmentOptionalized[]>appts)[0].patientId, patientId,
-        "patient_id column must be aliased to patientId in MANY_TO_ONE secondary SELECT");
+    error? testError = ();
+    do {
+        // PostgreSQL sequences may not return lastInsertId via batchExecute — query to get the generated ID.
+        stream<Patient, persist:Error?> pStream = postgresSqlDbHospital->/patients.get();
+        Patient[] pFound = check from Patient p in pStream where p.name == "Alias Test Patient" select p;
+        if pFound.length() == 0 {
+            check error("Could not find seeded patient 'Alias Test Patient'");
+        }
+        int patientId = pFound[0].id;
+        _ = check postgresSqlDbHospital->/appointments.post([{id: 50, patientId: patientId, doctorId: 50, appointmentTime: {year: 2024, month: 3, day: 20, hour: 10, minute: 0}, status: "SCHEDULED", reason: "Routine check"}]);
 
-    // stream path
-    stream<PatientWithRelations, persist:Error?> patientStream = postgresSqlDbHospital->/patients.get();
-    PatientWithRelations[] patients = check from PatientWithRelations p in patientStream
-        where p.name == "Alias Test Patient"
-        select p;
-    AppointmentOptionalized[]? apptsFromStream = patients[0].appointments;
-    if apptsFromStream is () {
-        test:assertFail("appointments array should be populated in stream path");
+        // queryOne: PatientWithRelations triggers MANY_TO_ONE secondary SELECT.
+        // patient_id column must be aliased to patientId for AppointmentOptionalized mapping to succeed.
+        PatientWithRelations patient = check postgresSqlDbHospital->/patients/[patientId].get();
+        AppointmentOptionalized[]? appts = patient.appointments;
+        test:assertTrue(appts is AppointmentOptionalized[], "appointments array should be populated");
+        test:assertEquals((<AppointmentOptionalized[]>appts).length(), 1);
+        test:assertEquals((<AppointmentOptionalized[]>appts)[0].patientId, patientId,
+            "patient_id column must be aliased to patientId in MANY_TO_ONE secondary SELECT");
+
+        // stream path
+        stream<PatientWithRelations, persist:Error?> patientStream = postgresSqlDbHospital->/patients.get();
+        PatientWithRelations[] patients = check from PatientWithRelations p in patientStream
+            where p.name == "Alias Test Patient"
+            select p;
+        if patients.length() != 1 {
+            check error("Expected exactly 1 patient named 'Alias Test Patient' in stream path, got " + patients.length().toString());
+        }
+        AppointmentOptionalized[]? apptsFromStream = patients[0].appointments;
+        if apptsFromStream is () {
+            test:assertFail("appointments array should be populated in stream path");
+        }
+        if apptsFromStream.length() != 1 {
+            test:assertFail("there should be 1 appointment in stream path");
+        }
+        test:assertEquals(apptsFromStream[0].patientId, patientId,
+            "patient_id column must be aliased to patientId in stream path");
+    } on fail error e {
+        testError = e;
     }
-    if apptsFromStream.length() != 1 {
-        test:assertFail("there should be 1 appointment in stream path");
-    }
-    test:assertEquals(apptsFromStream[0].patientId, patientId,
-        "patient_id column must be aliased to patientId in stream path");
 
     check postgresSqlDbHospital.close();
+    return testError;
 }
 
 @test:Config {
@@ -405,27 +418,34 @@ function testPatientWithAppointmentsManyRelationColumnAliasPostgreSql() returns 
 function testDoctorWithAppointmentsManyRelationColumnAliasPostgreSql() returns error? {
     PostgreSqlHospitalClient postgresSqlDbHospital = check new ();
 
-    DoctorWithRelations doctor = check postgresSqlDbHospital->/doctors/[50].get();
-    AppointmentOptionalized[]? appts = doctor.appointments;
-    test:assertTrue(appts is AppointmentOptionalized[], "doctor appointments should be populated");
-    test:assertEquals((<AppointmentOptionalized[]>appts).length(), 1);
-    test:assertNotEquals((<AppointmentOptionalized[]>appts)[0].patientId, (),
-        "patientId should be mapped from patient_id column in doctor's appointment list");
+    error? testError = ();
+    do {
+        DoctorWithRelations doctor = check postgresSqlDbHospital->/doctors/[50].get();
+        AppointmentOptionalized[]? appts = doctor.appointments;
+        test:assertTrue(appts is AppointmentOptionalized[], "doctor appointments should be populated");
+        test:assertEquals((<AppointmentOptionalized[]>appts).length(), 1);
+        test:assertNotEquals((<AppointmentOptionalized[]>appts)[0].patientId, (),
+            "patientId should be mapped from patient_id column in doctor's appointment list");
 
-    stream<DoctorWithRelations, persist:Error?> doctorStream = postgresSqlDbHospital->/doctors.get();
-    DoctorWithRelations[] doctors = check from DoctorWithRelations d in doctorStream
-        where d.name == "Dr. Alias Test"
-        select d;
-    test:assertEquals(doctors.length(), 1);
-    AppointmentOptionalized[]? appointments = doctors[0].appointments;
-    if appointments is () {
-        test:assertFail("appointments should be populated in stream path");
+        stream<DoctorWithRelations, persist:Error?> doctorStream = postgresSqlDbHospital->/doctors.get();
+        DoctorWithRelations[] doctors = check from DoctorWithRelations d in doctorStream
+            where d.name == "Dr. Alias Test"
+            select d;
+        if doctors.length() != 1 {
+            check error("Expected exactly 1 doctor named 'Dr. Alias Test' in stream path, got " + doctors.length().toString());
+        }
+        AppointmentOptionalized[]? appointments = doctors[0].appointments;
+        if appointments is () {
+            test:assertFail("appointments should be populated in stream path");
+        }
+        if appointments.length() != 1 {
+            test:assertFail("there should be 1 appointment in stream path");
+        }
+        test:assertNotEquals(appointments[0].patientId, (),
+            "patientId should be correctly mapped in doctor stream path");
+    } on fail error e {
+        testError = e;
     }
-    if appointments.length() != 1 {
-        test:assertFail("there should be 1 appointment in stream path");
-    }
-    test:assertNotEquals(appointments[0].patientId, (),
-        "patientId should be correctly mapped in doctor stream path");
 
     _ = check postgresSqlDbHospital->/appointments/[50].delete();
     _ = check postgresSqlDbHospital->/doctors/[50].delete();
@@ -437,4 +457,5 @@ function testDoctorWithAppointmentsManyRelationColumnAliasPostgreSql() returns e
         _ = check postgresSqlDbHospital->/patients/[p.id].delete();
     }
     check postgresSqlDbHospital.close();
+    return testError;
 }

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,12 @@ This file contains all the notable changes done to the Ballerina Persist SQL pac
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- [Fix MANY_TO_ONE secondary SELECT not aliasing SQL column names to Ballerina field names when `refColumn` differs from `refField`](https://github.com/ballerina-platform/ballerina-library/issues/8764).
+
 ## [1.7.1] - 2026-02-12
 
 ### Fixed

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Fix MANY_TO_ONE secondary SELECT not aliasing SQL column names to Ballerina field names when `refColumn` differs from `refField`](https://github.com/ballerina-platform/ballerina-library/issues/8764).
 
+## [1.7.3] - 2026-03-26
+
+Documentation and metadata updates only (README, keywords). No API or behaviour changes.
+
+## [1.7.2] - 2026-02-24
+
+### Fixed
+
+- [Fix array (MANY_TO_ONE) relations not populated in queryAsList](https://github.com/ballerina-platform/module-ballerinax-persist.sql/pull/117)
+
 ## [1.7.1] - 2026-02-12
 
 ### Fixed


### PR DESCRIPTION
## Purpose

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/8764

## Examples

N/A

## Checklist
- [x] Linked to an issue
- [ ] ~Updated the specification~
- [x] Updated the changelog
- [x] Added tests
- [ ] ~Checked native-image compatibility~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request fixes a runtime issue in MANY_TO_ONE relation query generation where SQL column names were not being aliased to their corresponding Ballerina field names. This caused failures when the related entity used name annotations to map snake_case SQL columns to camelCase Ballerina fields.

## Changes

**Core Fix:**
- Updated `sql_client.bal` to distinguish between the SQL column name (`refColumn`) and the Ballerina field name (`refField`) in the many-relation SELECT construction. When these differ, the selected column is now aliased to the expected field name, ensuring correct result mapping into target record types.

**Test Coverage:**
- Added comprehensive regression tests across H2, MSSQL, MySQL, and PostgreSQL test suites to validate MANY_TO_ONE relation column aliasing when patient ID fields use snake_case SQL naming (`patient_id`) mapped to camelCase Ballerina fields (`patientId`).
- Tests verify both direct entity fetch and streaming query paths work correctly with the new aliasing behavior.

**Version and Dependency Updates:**
- Bumped module version from 1.7.3 to 1.7.4
- Updated platform dependencies and compiler plugin references to point to 1.7.4-SNAPSHOT artifacts
- Updated dependency manifest with current versions of related `ballerina` and `ballerinax` packages

**Documentation:**
- Added changelog entry documenting the fix for MANY_TO_ONE secondary SELECT column aliasing

The fix is targeted to MANY_TO_ONE relation queries and preserves existing behavior for other relation types (ONE_TO_ONE, ONE_TO_MANY).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->